### PR TITLE
モバイル対応2点

### DIFF
--- a/src/denryusen.php
+++ b/src/denryusen.php
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET["mv"]) ?> まで"/>
 <meta property="og:description" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET["mv"]) ?> まで"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "..";

--- a/src/denryusen_multi.ejs
+++ b/src/denryusen_multi.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -20,6 +20,7 @@
 .boardset { width: 580px; flex: 0 0 auto; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "..";

--- a/src/denryusen_multi_test1.ejs
+++ b/src/denryusen_multi_test1.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -20,6 +20,7 @@
 .boardset { width: 580px; flex: 0 0 auto; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test1";

--- a/src/denryusen_multi_test2.ejs
+++ b/src/denryusen_multi_test2.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -20,6 +20,7 @@
 .boardset { width: 580px; flex: 0 0 auto; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test2";

--- a/src/denryusen_multi_test3.ejs
+++ b/src/denryusen_multi_test3.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(複数棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -20,6 +20,7 @@
 .boardset { width: 580px; flex: 0 0 auto; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test3";

--- a/src/denryusen_single.ejs
+++ b/src/denryusen_single.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "..";

--- a/src/denryusen_single_test1.ejs
+++ b/src/denryusen_single_test1.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test1";

--- a/src/denryusen_single_test2.ejs
+++ b/src/denryusen_single_test2.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test2";

--- a/src/denryusen_single_test3.ejs
+++ b/src/denryusen_single_test3.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:description" content="第1回電竜戦 棋譜中継(単一棋譜)"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test3";

--- a/src/denryusen_test1.php
+++ b/src/denryusen_test1.php
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:description" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test1";

--- a/src/denryusen_test2.php
+++ b/src/denryusen_test2.php
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:description" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test2";

--- a/src/denryusen_test3.php
+++ b/src/denryusen_test3.php
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:description" content="第1回電竜戦 <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:site_name" content="電竜戦"/>
@@ -18,6 +18,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var denryuUrlBase = "https://p.mzr.jp/denryusen/dr1_test3";

--- a/src/floodgate.php
+++ b/src/floodgate.php
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="floodgate <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:description" content="floodgate <?php echo htmlspecialchars($_GET["gn"]) ?> <?php echo htmlspecialchars($_GET["te"]) ?>手目 <?php echo htmlspecialchars($_GET[mv]) ?> まで"/>
 <meta property="og:site_name" content="floodgate"/>
@@ -16,6 +16,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var gameBoardProp = {

--- a/src/floodgate_multi.ejs
+++ b/src/floodgate_multi.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="floodgate 棋譜中継(複数棋譜)"/>
 <meta property="og:description" content="floodgate 棋譜中継(複数棋譜)"/>
 <meta property="og:site_name" content="floodgate"/>
@@ -18,6 +18,7 @@
 .boardset { width: 580px; flex: 0 0 auto; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var gameBoardProp = {

--- a/src/floodgate_single.ejs
+++ b/src/floodgate_single.ejs
@@ -2,7 +2,7 @@
 <html lang="ja" prefix="og: http://ogp.me/ns#">
 <head>
 <meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <meta property="og:title" content="floodgate 棋譜中継(単一棋譜)"/>
 <meta property="og:description" content="floodgate 棋譜中継(単一棋譜)"/>
 <meta property="og:site_name" content="floodgate"/>
@@ -16,6 +16,7 @@
 .boardset, .boardset .nav, .boardset svg.boardset, .boardset p.kifu, .boardset pre.reason { width: 570px; }
 .icon-tabler { font-size: inherit; width: 1em; height: 1em; vertical-align: -.125em; }
 .icon-tabler-brand-twitter { color: #1da1f2; }
+button { touch-action: manipulation; }
 </style>
 <script type="text/javascript">
 var gameBoardProp = {


### PR DESCRIPTION
モバイル表示時の煩わしいズーム挙動を修正しました。

## 1. ボタンの連続タップでズームしてしまう

![mv1](https://user-images.githubusercontent.com/3267290/92300895-ae358800-ef99-11ea-9645-36bf2656802c.gif)

button タグに `touch-action: manipulation;` スタイルを付与

ref: https://developer.mozilla.org/ja/docs/Web/CSS/touch-action

> manipulation
> パンおよびズームのジェスチャーは有効にしますが、ダブルタップでのズームなど、標準外の追加的なジェスチャーを無効します。

## 2. セレクトボックス(手数選択など)でズームしてしまう

![mv2](https://user-images.githubusercontent.com/3267290/92300934-171d0000-ef9a-11ea-8ae7-a89c953d5596.gif)

viewport に `user-scalable=no` を付与。
このオプションを指定しても、ピンチインズームは問題なく動作します。